### PR TITLE
Addition of Wireguard-Go to the images.

### DIFF
--- a/docs/containers/qbittorrent.md
+++ b/docs/containers/qbittorrent.md
@@ -124,3 +124,5 @@ This image comes bundled with the alternative Web UI VueTorrent, to enable it yo
 <img src="/img/vuetorrentsettings.png" alt="vuetorrentsettings" width="300">
 
 --8<-- "includes/wireguard.md"
+
+--8<-- "includes/wireguard-go.md"

--- a/docs/containers/qflood.md
+++ b/docs/containers/qflood.md
@@ -128,3 +128,5 @@ In most cases you'll need to add additional volumes, depending on your own perso
 Under certain circumstances it's required to run the WebUI on a different internal port, you can do that by modifying the environment variable `WEBUI_PORTS` accordingly. It should be in the format `xxxx/tcp,xxxx/udp`, take a look at the default with `docker logs` (variable is printed at container start) or `docker inspect`.
 
 --8<-- "includes/wireguard.md"
+
+--8<-- "includes/wireguard-go.md"

--- a/docs/containers/rflood.md
+++ b/docs/containers/rflood.md
@@ -120,3 +120,5 @@ In most cases you'll need to add additional volumes, depending on your own perso
 Under certain circumstances it's required to run the WebUI on a different internal port, you can do that by modifying the environment variable `WEBUI_PORTS` accordingly. It should be in the format `xxxx/tcp,xxxx/udp`, take a look at the default with `docker logs` (variable is printed at container start) or `docker inspect`.
 
 --8<-- "includes/wireguard.md"
+
+--8<-- "includes/wireguard-go.md"

--- a/includes/wireguard-go.md
+++ b/includes/wireguard-go.md
@@ -1,0 +1,28 @@
+## Wireguard-Go (Userspace VPN)
+
+This brings Support for Synology, Qnap, Systems with missing Modules.
+Synology and other NAS systems are often missing the kernel modules needed for Wireguard. This often requires "System Hacks" to force-fully add the missing Modules.
+This image here contains Wireguard-Go, which implements Wireguard in Userspace. It starts automatically, if the Kernel Modules are not found. 
+It requires the two changes below to allow to use Wireguard.
+
+### Additional Config for NAS
+
+*wg0.conf*
+A change to the `wg0.conf` is needed, due a long lasting bug in Wireguard with such systems.
+You need to change the AllowedIPs line to have Wireguard start up properly.
+
+```AllowedIPs = 0.0.0.0/1,128.0.0.1```
+
+*Docker additions*
+
+For Synos and other such systems, it is needed to add the device mapping.
+
+Docker-Compose:
+```    devices:
+      - /dev/net/tun:/dev/net/tun
+```
+      
+For Docker run:
+```
+--device /dev/net/tun:/dev/net/tun
+```


### PR DESCRIPTION
This PR adds the readme for the Wireguard-Go addition to enable WG in Userspace in case of missing kernel modules