### PR TITLE
add qnap to WireGuard GO heading

### DIFF
--- a/docs/containers/qbittorrent.md
+++ b/docs/containers/qbittorrent.md
@@ -124,7 +124,7 @@ This image comes bundled with the alternative Web UI VueTorrent, to enable it yo
 
 --8<-- "includes/wireguard.md"
 
-## Synology (WireGuard Go)
+## Synology and QNAP (WireGuard Go)
 
 === "cli"
 


### PR DESCRIPTION
People may gloss over the fact systems besides Synology may or will require the same changes if the heading is only calling out Synology. Adding other systems could encourage further reading and fewer issues.